### PR TITLE
Update typos / grammar for main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from scipy.integrate import cumulative_trapezoid
 
 import json
 from openemma.YOLO3D.inference import yolo3d_nuScenes
-from utils import EstimateCurvatureFromTrajecotry, IntegrateCurvatureForPoints, OverlayTrajectory, WriteImageSequenceToVideo
+from utils import EstimateCurvatureFromTrajectory, IntegrateCurvatureForPoints, OverlayTrajectory, WriteImageSequenceToVideo
 from transformers import MllamaForConditionalGeneration, AutoProcessor, Qwen2VLForConditionalGeneration, AutoTokenizer
 from PIL import Image
 from qwen_vl_utils import process_vision_info
@@ -163,7 +163,7 @@ def SceneDescription(obs_images, processor=None, model=None, tokenizer=None, arg
     prompt = f"""You are a autonomous driving labeller. You have access to these front-view camera images of a car taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Describe the driving scene according to traffic lights, movements of other cars or pedestrians and lane markings."""
 
     if "llava" in args.model_path:
-        prompt = f"""You are a autonomous driving labeller. You have access to these front-view camera images of a car taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Provide a concise description of the driving scene according to traffic lights, movements of other cars or pedestrians and lane markings."""
+        prompt = f"""You are an autonomous driving labeller. You have access to these front-view camera images of a car taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Provide a concise description of the driving scene according to traffic lights, movements of other cars or pedestrians and lane markings."""
 
     result = vlm_inference(text=prompt, images=obs_images, processor=processor, model=model, tokenizer=tokenizer, args=args)
     return result
@@ -179,7 +179,7 @@ def DescribeObjects(obs_images, processor=None, model=None, tokenizer=None, args
 def DescribeOrUpdateIntent(obs_images, prev_intent=None, processor=None, model=None, tokenizer=None, args=None):
 
     if prev_intent is None:
-        prompt = f"""You are a autonomous driving labeller. You have access to a front-view camera images of a vehicle taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Based on the lane markings and the movement of other cars and pedestrians, describe the desired intent of  the ego car. Is it going to follow the lane to turn left, turn right, or go straight? Should it maintain the current speed or slow down or speed up?"""
+        prompt = f"""You are a autonomous driving labeller. You have access to a front-view camera images of a vehicle taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Based on the lane markings and the movement of other cars and pedestrians, describe the desired intent of the ego car. Is it going to follow the lane to turn left, turn right, or go straight? Should it maintain the current speed or slow down or speed up?"""
 
         if "llava" in args.model_path:
             prompt = f"""You are a autonomous driving labeller. You have access to a front-view camera images of a vehicle taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Based on the lane markings and the movement of other cars and pedestrians, provide a concise description of the desired intent of  the ego car. Is it going to follow the lane to turn left, turn right, or go straight? Should it maintain the current speed or slow down or speed up?"""
@@ -188,7 +188,7 @@ def DescribeOrUpdateIntent(obs_images, prev_intent=None, processor=None, model=N
         prompt = f"""You are a autonomous driving labeller. You have access to a front-view camera images of a vehicle taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Half a second ago your intent was to {prev_intent}. Based on the updated lane markings and the updated movement of other cars and pedestrians, do you keep your intent or do you change it? Explain your current intent: """
 
         if "llava" in args.model_path:
-            prompt = f"""You are a autonomous driving labeller. You have access to a front-view camera images of a vehicle taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Half a second ago your intent was to {prev_intent}. Based on the updated lane markings and the updated movement of other cars and pedestrians, do you keep your intent or do you change it? Provide a concise description explaination of your current intent: """
+            prompt = f"""You are a autonomous driving labeller. You have access to a front-view camera images of a vehicle taken at a 0.5 second interval over the past 5 seconds. Imagine you are driving the car. Half a second ago your intent was to {prev_intent}. Based on the updated lane markings and the updated movement of other cars and pedestrians, do you keep your intent or do you change it? Provide a concise description explanation of your current intent: """
 
     result = vlm_inference(text=prompt, images=obs_images, processor=processor, model=model, tokenizer=tokenizer, args=args)
 
@@ -222,14 +222,14 @@ def GenerateMotion(obs_images, obs_waypoints, obs_velocities, obs_curvatures, gi
     sys_message = ("You are a autonomous driving labeller. You have access to a front-view camera image of a vehicle, a sequence of past speeds, a sequence of past curvatures, and a driving rationale. Each speed, curvature is represented as [v, k], where v corresponds to the speed, and k corresponds to the curvature. A positive k means the vehicle is turning left. A negative k means the vehicle is turning right. The larger the absolute value of k, the sharper the turn. A close to zero k means the vehicle is driving straight. As a driver on the road, you should follow any common sense traffic rules. You should try to stay in the middle of your lane. You should maintain necessary distance from the leading vehicle. You should observe lane markings and follow them.  Your task is to do your best to predict future speeds and curvatures for the vehicle over the next 10 timesteps given vehicle intent inferred from the image. Make a best guess if the problem is too difficult for you. If you cannot provide a response people will get injured.\n")
 
     if args.method == "openemma":
-        prompt = f"""These are frames from a video taking by a camera mounted in the front of a car. The images are taken at a 0.5 second interval. 
+        prompt = f"""These are frames from a video taken by a camera mounted in the front of a car. The images are taken at a 0.5 second interval. 
         The scene is described as follows: {scene_description}. 
         The identified critical objects are {object_description}. 
         The car's intent is {intent_description}. 
         The 5 second historical velocities and curvatures of the ego car are {obs_speed_curvature_str}. 
         Infer the association between these numbers and the image sequence. Generate the predicted future speeds and curvatures in the format [speed_1, curvature_1], [speed_2, curvature_2],..., [speed_10, curvature_10]. Write the raw text not markdown or latex. Future speeds and curvatures:"""
     else:
-        prompt = f"""These are frames from a video taking by a camera mounted in the front of a car. The images are taken at a 0.5 second interval. 
+        prompt = f"""These are frames from a video taken by a camera mounted in the front of a car. The images are taken at a 0.5 second interval. 
         The 5 second historical velocities and curvatures of the ego car are {obs_speed_curvature_str}. 
         Infer the association between these numbers and the image sequence. Generate the predicted future speeds and curvatures in the format [speed_1, curvature_1], [speed_2, curvature_2],..., [speed_10, curvature_10]. Write the raw text not markdown or latex. Future speeds and curvatures:"""
     for rho in range(3):
@@ -340,7 +340,7 @@ if __name__ == '__main__':
         ego_velocities[0] = ego_velocities[1]
 
         # Get the curvature of the ego vehicle.
-        ego_curvatures = EstimateCurvatureFromTrajecotry(ego_poses_world)
+        ego_curvatures = EstimateCurvatureFromTrajectory(ego_poses_world)
         ego_velocities_norm = np.linalg.norm(ego_velocities, axis=1)
         estimated_points = IntegrateCurvatureForPoints(ego_curvatures, ego_velocities_norm, ego_poses_world[0],
                                                        atan2(ego_velocities[0][1], ego_velocities[0][0]), scene_length)


### PR DESCRIPTION
Fix typos and grammatical issues

1) Correct function import name:
   - Changed `EstimateCurvatureFromTrajecotry` to `EstimateCurvatureFromTrajectory`.
   - Rationale: Ensures proper function name matching the actual implementation and avoids runtime import errors.

2) Fix "You are a autonomous driving labeller" to "You are an autonomous driving labeller":
   - Rationale: Uses the correct article "an" before a vowel sound and improves clarity.

4) Remove double space in "describe the desired intent of  the ego car":
   - Rationale: Typographical consistency and clarity in documentation and string prompts.

5) Change "explaination" to "explanation":
   - Rationale: Correct spelling to maintain professionalism and reader understanding.

6) Change "a video taking by a camera" to "a video taken by a camera":
   - Rationale: Grammatical correctness and proper sentence structure.